### PR TITLE
🐛 Fix `npm run start` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is an example project demonstrating how to use Hatchet with Typescript.",
   "main": "index.js",
   "scripts": {
-    "start": "node dist/worker.js",
+    "start": "node dist/src/worker.js",
     "run:simple": "npx ts-node src/run.ts",
     "build": "tsc --outDir dist"
   },


### PR DESCRIPTION
When building the project via `npm run build` a `dist` dir is getting generated with this content 
```
ls dist
monorepo src
```
The package.json "start" command is missing the `src` dir to find the `worker.js`.